### PR TITLE
Add reproducible p‑value tests and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,33 @@ Metrics to compute and plot:
 * AUC = Area Under the Curve
 * NRI = Net Reclassification Index
 * IDI = Integrated Discrimination Improvement
+* Functions to compute bootstrap p-values for AUC and NRI differences
 
 Run "example.ipynb" Jupyter notebook to see and use functions
+
+## Installation
+```bash
+pip install -r requirements.txt
+pip install .
+```
+
+## Running tests
+```bash
+pytest -q
+```
+
+## Formulas
+**AUC**
+\[AUC = \int_0^1 TPR(FPR)\, dFPR \]
+
+**NRI**
+\[NRI = (P_{\text{up}|\text{event}} - P_{\text{down}|\text{event}}) + (P_{\text{down}|\text{non-event}} - P_{\text{up}|\text{non-event}})\]
+
+**IDI**
+\[IDI = (\bar{p}_{\text{new},1} - \bar{p}_{\text{ref},1}) - (\bar{p}_{\text{new},0} - \bar{p}_{\text{ref},0})\]
+
+## Usage
+Import the package and call any metric helpers. See the example notebook for a detailed walkthrough.
 
 Code and concepts further explained in the following post: "[Area Under the Curve and Beyond](https://www.lambertleong.com/thoughts/AUC-IDI-NRI)" or "[On Medium/Towards Data Science](https://medium.com/towards-data-science/area-under-the-curve-and-beyond-f87a8ec6937b)"
 

--- a/testing/test_nri.py
+++ b/testing/test_nri.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 # Add the parent directory to sys.path
 sys.path.append(str(Path(__file__).parent.parent))
-from more_metrics import calculate_nri, category_free_nri, check_cat, track_movement
+from more_metrics import calculate_nri, category_free_nri, check_cat, track_movement, nri_pvalue
 
 def test_track_movement():
     ref = np.array([0.1, 0.2, 0.3, 0.4])
@@ -65,4 +65,57 @@ def test_category_free_nri_valid_results():
     assert isinstance(nri_events, float)
     assert isinstance(nri_nonevents, float)
     assert isinstance(total_nri, float)
+
+def test_nri_pvalue_range():
+    y_truth = np.array([0, 1, 0, 1, 0])
+    y_ref = np.array([0.1, 0.6, 0.2, 0.7, 0.3])
+    y_new = np.array([0.2, 0.7, 0.1, 0.8, 0.4])
+    risk_thresholds = [0.3, 0.6]
+
+    mean_nri, pval = nri_pvalue(y_truth, y_ref, y_new, risk_thresholds, num_bootstraps=50)
+    assert isinstance(mean_nri, float)
+    assert isinstance(pval, float)
+    assert 0 <= pval <= 1
+
+def test_nri_pvalue_identical_predictions():
+    truth = np.array([0, 1, 0, 1])
+    preds = np.array([0.2, 0.7, 0.1, 0.8])
+    thresholds = [0.3, 0.6]
+
+    mean_nri, pval = nri_pvalue(truth, preds, preds, thresholds, num_bootstraps=20)
+    assert mean_nri == pytest.approx(0.0)
+    assert pval == pytest.approx(1.0)
+
+def test_nri_pvalue_significant_difference():
+    truth = np.array([0, 0, 1, 1])
+    ref = np.array([0.5, 0.5, 0.5, 0.5])
+    new = np.array([0.2, 0.2, 0.8, 0.8])
+    thresholds = [0.3, 0.6]
+
+    mean_nri, pval = nri_pvalue(truth, ref, new, thresholds, num_bootstraps=20)
+    assert mean_nri > 1.0
+    assert pval < 0.01
+
+def test_nri_pvalue_invalid_inputs():
+    truth = np.array([0, 1])
+    ref = np.array([0.1, 0.4])
+    new = np.array([0.2])
+
+    with pytest.raises(ValueError):
+        nri_pvalue(truth, ref, new, [0.3, 0.6])
+
+    with pytest.raises(TypeError):
+        nri_pvalue([0, 1], [0.1, 0.4], [0.2, 0.3], [0.3, 0.6])
+
+def test_nri_pvalue_reproducible():
+    truth = np.array([0, 1, 0, 1])
+    ref = np.array([0.1, 0.6, 0.2, 0.7])
+    new = np.array([0.2, 0.7, 0.1, 0.8])
+    thresholds = [0.3, 0.6]
+
+    nri1, pval1 = nri_pvalue(truth, ref, new, thresholds, num_bootstraps=30)
+    nri2, pval2 = nri_pvalue(truth, ref, new, thresholds, num_bootstraps=30)
+
+    assert nri1 == pytest.approx(nri2)
+    assert pval1 == pytest.approx(pval2)
 


### PR DESCRIPTION
## Summary
- document installation, formulas and usage
- add tests verifying p-value helper reproducibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684607a6453883289a46a08c26f9c5da